### PR TITLE
MySQLコンテナ起動時に初期データが投入されるようにする

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,5 +25,6 @@ services:
       TZ: "Asia/Tokyo"
     volumes:
       - ./my.cnf:/etc/mysql/conf.d/my.cnf
+      - ./src/db:/docker-entrypoint-initdb.d
 volumes:
   node_modules:

--- a/src/db/init.sql
+++ b/src/db/init.sql
@@ -1,0 +1,17 @@
+DROP DATABASE IF EXISTS development;
+CREATE DATABASE development;
+
+USE development;
+
+DROP TABLE IF EXISTS users;
+
+CREATE TABLE users (
+    id int NOT NULL AUTO_INCREMENT primary key,
+    name varchar(30)
+);
+
+INSERT INTO users (id, name) VALUES (1, 'Junya');
+INSERT INTO users (id, name) VALUES (2, 'Kanta');
+INSERT INTO users (id, name) VALUES (3, 'Motoki');
+INSERT INTO users (id, name) VALUES (4, 'Taisei');
+INSERT INTO users (id, name) VALUES (5, 'Yuto');


### PR DESCRIPTION
## **概要**

MySQLイメージからコンテナを生成・起動する時に、`init.sql`ファイルを読み込み、テーブルの生成、初期データが投入されるようにする。

## **このPRがマージされるとうれしいこと**

- `init.sql`ファイルにテーブルや制約をまとめて書いておくことでDBの管理がしやすくなる。
- 設計などが決まったら`init.sql`ファイルにまとめて書いておけると良さそうと思ったのだけど、他に良い方法があれば教えてもらえると嬉しいです〜

## 備考

```bash
#一回volumeを削除しないといけないので下記を実行
docker-compose down -v 
docker-comopose up 
```

- MySQLの確認方法とか

```bash
#DBのコンテナに入る
docker-compose exec db /bin/bash
#ログイン
mysql -u root -p
#developmentデータベースを選択 
use development;
#仮で作成したusersテーブルが作成されていればOK
show tables;
select * from users;

```

## 参考

- [https://qiita.com/NagaokaKenichi/items/ae037963b33a85df33f5](https://qiita.com/NagaokaKenichi/items/ae037963b33a85df33f5)
- [https://docs.docker.com/samples/library/mysql/#docker-secrets](https://docs.docker.com/samples/library/mysql/#docker-secrets)